### PR TITLE
Enabled Directory and File Creation for Files that Don't Exist at Runtime

### DIFF
--- a/download_ssara_rsmas.py
+++ b/download_ssara_rsmas.py
@@ -27,6 +27,7 @@ def create_parser():
 
     return parser
 
+
 def command_line_parse(args):
     """ Parses command line agurments into inps variable. """
 
@@ -34,6 +35,7 @@ def command_line_parse(args):
 
     parser = create_parser()
     inps = parser.parse_args(args)
+
 
 def check_downloads(run_number, args):
     """ Checks if all of the ssara files to be dwonloaded actually exist.
@@ -57,7 +59,7 @@ def check_downloads(run_number, args):
 
     for f in files_to_check:
         if not os.path.isfile(str(os.getcwd()) + "/" + str(f)):
-            logger.log(logging.WARNING, "The file, %s, didn't download correctly. Running ssara again.")
+            logger.log(loglevel.WARNING, "The file, %s, didn't download correctly. Running ssara again.")
             run_ssara(run_number + 1)
             return
 
@@ -95,7 +97,7 @@ def run_ssara(run_number=1):
 
     completion_status = ssara_process.poll()  # the completion status of the process
     hang_status = False  # whether or not the download has hung
-    wait_time = 10  # wait time in 'minutes' to determine hang status
+    wait_time = 6  # wait time in 'minutes' to determine hang status
     prev_size = -1  # initial download directory size
     i = 0  # the iteration number (for logging only)
 
@@ -112,7 +114,7 @@ def run_ssara(run_number=1):
             hang_status = True
             logger.log(loglevel.WARNING, "SSARA Hung")
             ssara_process.terminate()  # teminate the process beacause download hung
-            break;  # break the completion loop 
+            break  # break the completion loop
 
         time.sleep(60 * wait_time)  # wait 'wait_time' minutes before continuing
         prev_size = curr_size

--- a/generate_templates.py
+++ b/generate_templates.py
@@ -175,6 +175,8 @@ def main(args):
     if inps.output:
         output_location = inps.output
 
+    os.makedirs(os.path.dirname(output_location), exist_ok=True)
+
     df = get_spreadsheet_as_dataframe(csv_file, output_location)
     generate_and_save_template_files_from_dataframe(df, output_location)
 

--- a/generate_templates.py
+++ b/generate_templates.py
@@ -7,17 +7,10 @@ import requests
 import argparse
 import time
 import logging
+from rsmas_logging import rsmas_logger, loglevel
 from datetime import datetime
 
-logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
-
-std_formatter = logging.Formatter("%(levelname)s - %(message)s")
-
-general = logging.FileHandler(os.getenv('OPERATIONS')+'/LOGS/generate_templates.log', 'a+', encoding=None)
-general.setLevel(logging.INFO)
-general.setFormatter(std_formatter)
-logger.addHandler(general)
+logger = rsmas_logger(os.getenv('OPERATIONS')+'/LOGS/generate_templates.log')
 
 
 inps = None
@@ -146,7 +139,7 @@ def generate_and_save_template_files(df, output_location):
 
     files_to_save = generate_template_files(df)
     
-    logging.info("Template files being generated for: %s", str(files_to_save))
+    logger.log(loglevel.INFO, "Template files being generated for: %s", str(files_to_save))
 
     for key, value in files_to_save.items():
         # Print contents for debugging purposes
@@ -168,7 +161,7 @@ def generate_and_save_template_files_from_dataframe(df, output_location):
 
 def main(args):
     
-    logger.info("GENERATING TEMPLATES ON %s\n", datetime.fromtimestamp(time.time()).strftime(date_format))
+    logger.log(loglevel.INFO, "GENERATING TEMPLATES ON %s\n", datetime.fromtimestamp(time.time()).strftime(date_format))
     
     inps = cmdLineParse(args)
 

--- a/generate_templates.py
+++ b/generate_templates.py
@@ -6,7 +6,6 @@ import sys
 import requests
 import argparse
 import time
-import logging
 from rsmas_logging import rsmas_logger, loglevel
 from datetime import datetime
 
@@ -65,10 +64,6 @@ def get_spreadsheet_as_dataframe(file, output_file_location, output_type = "csv"
     else:
         df = get_google_spreadsheet_as_dataframe(file, output_file_location, output_type)
     return df
-
-
-
-##########################################################
 
 
 def generate_template_file(names, subnames, column_vals, comments):
@@ -146,7 +141,9 @@ def generate_and_save_template_files(df, output_location):
         if value == None:
             continue;
 
-        with open(os.path.join(output_location, key + ".template"), "w") as f:
+        filename = os.path.join(output_location, key + ".template")
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
+        with open(filename, "w") as f:
             f.write(value)
 
 

--- a/rsmas_logging.py
+++ b/rsmas_logging.py
@@ -1,3 +1,4 @@
+import os
 import logging
 from enum import Enum
 
@@ -23,6 +24,9 @@ class rsmas_logger():
         self.set_format(self.format)
 
     def setup_filehandler(self, formatter):
+
+        os.makedirs(os.path.dirname(self.logfile_name), exist_ok=True)
+
         file_handler = logging.FileHandler(self.logfile_name, 'a+', encoding=None)
         file_handler.setLevel(logging.DEBUG)
         file_handler.setFormatter(formatter)

--- a/run_operations.py
+++ b/run_operations.py
@@ -20,7 +20,7 @@ logger.setLevel(logging.DEBUG)
 
 std_formatter = logging.Formatter("%(message)s")
 
-general = logging.FileHandler(os.getenv('OPERATIONS')+'/LOGS/run_operations.log', 'a+', encoding=None)
+general = logging.FileHandler(os.getenv('OPERATIONS') + '/LOGS/run_operations.log', 'a+', encoding=None)
 general.setLevel(logging.INFO)
 general.setFormatter(std_formatter)
 logger.addHandler(general)
@@ -35,33 +35,31 @@ error_handler = None
 
 #################### GLOBAL VARIABLES ####################
 
-dataset = 'GalapagosSenDT128VV'		                				        # Single Dataset for Testing
+dataset = 'GalapagosSenDT128VV'  # Single Dataset for Testing
 
-user = subprocess.check_output(['whoami']).decode('utf-8').strip("\n")  			# Currently logged in user
-	
-stored_date = None			  							# previously stored date
-most_recent = None										# date parsed from SSARA
-inps = None;				       							# command line arguments
+user = subprocess.check_output(['whoami']).decode('utf-8').strip("\n")  # Currently logged in user
 
-job_to_dset = {}										# dictionary of jobs to datasets
+stored_date = None  # previously stored date
+most_recent = None  # date parsed from SSARA
+inps = None;  # command line arguments
 
-date_format = "%Y-%m-%dT%H:%M:%S.%f"								# date format for reading and writing dates
+job_to_dset = {}  # dictionary of jobs to datasets
 
-
+date_format = "%Y-%m-%dT%H:%M:%S.%f"  # date format for reading and writing dates
 
 
-"""
-    Initializes logging handlers for INFO level and ERROR level file logging. Needed so as to be able to continue logging
-    data to the appropiate dataset log after processSentinel completes.
-    Parameters: dset: str, the dataset to write log output for
-                mode: str, the logfile write mode (can be write or append)
-    Returns:    none
-"""
 def setup_logging_handlers(dset, mode):
+	""" Initializes logging handlers for INFO level and ERROR level file logging.
+		Needed so as to be able to continue logging data to the appropiate dataset log after processSentinel completes.
+
+		Parameters: dset: str, the dataset to write log output for
+					mode: str, the logfile write mode (can be write or append)
+		Returns:    none
+	"""
 	global info_handler, error_handler
-	
+
 	# create a file handler for INFO level logging
-	info_log_file = os.getenv('OPERATIONS')+'/LOGS/'+dset+'_info.log'
+	info_log_file = os.getenv('OPERATIONS') + '/LOGS/' + dset + '_info.log'
 	info_handler = logging.FileHandler(info_log_file, mode, encoding=None)
 	info_formatter = logging.Formatter("%(levelname)s - %(message)s")
 	info_handler.setLevel(logging.INFO)
@@ -69,7 +67,7 @@ def setup_logging_handlers(dset, mode):
 	logger.addHandler(info_handler)
 
 	# create a file handler for ERROR level logging
-	error_log_file = os.getenv('OPERATIONS')+'/LOGS/'+dset+'_error.log'
+	error_log_file = os.getenv('OPERATIONS') + '/LOGS/' + dset + '_error.log'
 	error_handler = logging.FileHandler(error_log_file, mode, encoding=None)
 	err_formatter = logging.Formatter("%(levelname)s - %(message)s")
 	error_handler.setLevel(logging.ERROR)
@@ -79,37 +77,44 @@ def setup_logging_handlers(dset, mode):
 
 ###################### Command Line Argument Processing #################
 
-"""
-    Defines commandline argument parser and command line arguments to accept
-    Parameters: none
-    Returns:    parser: argument parser object
-"""
 def create_process_sentinel_parser():
+	"""
+		Defines commandline argument parser and command line arguments to accept
+
+		Parameters: none
+		Returns:    parser: argument parser object
+	"""
 	parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
 
 	parser.add_argument('-v', '--version', action='version', version='%(prog)s 0.1')
 	parser.add_argument("--dataset", dest='dataset', metavar="DATASET", help='Particular dataset to run')
-	parser.add_argument('--templatecsv', dest='template_csv', metavar='FILE', help='local csv file containing template info.')
-	parser.add_argument('--singletemplate', dest='single_template', metavar='FILE', help='singular template file to run on')
+	parser.add_argument('--templatecsv', dest='template_csv', metavar='FILE',
+						help='local csv file containing template info.')
+	parser.add_argument('--singletemplate', dest='single_template', metavar='FILE',
+						help='singular template file to run on')
 	parser.add_argument('--startssara', dest='startssara', action='store_true', help='process_sentinel.py --startssara')
-	parser.add_argument('--startprocess', dest='startprocess', action='store_true', help='process using sentinelstack package')
+	parser.add_argument('--startprocess', dest='startprocess', action='store_true',
+						help='process using sentinelstack package')
 	parser.add_argument('--startpysar', dest='startpysar', action='store_true', help='run pysar')
 	parser.add_argument('--startinsarmaps', dest='startinsarmaps', action='store_true', help='ingest into insarmaps')
-	parser.add_argument("--testsheet", dest="test_sheet", action='store_true', help='whether or not to use the test sheet')
+	parser.add_argument("--testsheet", dest="test_sheet", action='store_true',
+						help='whether or not to use the test sheet')
 
 	return parser
 
-"""
-    Parses command line arguments into inps object as object parameters
-    Parameters: args: [str], array of command line arguments
-    Returns:    none
-"""	
+
 def command_line_parse(args):
+	"""
+		Parses command line arguments into inps object as object parameters
+
+		Parameters: args: [str], array of command line arguments
+		Returns:    none
+	"""
 	global inps;
 
 	parser = create_process_sentinel_parser()
 	inps = parser.parse_args(args)
-	
+
 	logger.info("\tCOMMAND LINE VARIABLES:")
 	logger.info("\t\t--dataset     	    : %s\n", inps.dataset)
 	logger.info("\t\t--templatecsv      : %s\n", inps.template_csv)
@@ -119,140 +124,146 @@ def command_line_parse(args):
 	logger.info("\t\t--startpysar       : %s\n", inps.startpysar)
 	logger.info("\t\t--startinsarmaps   : %s\n", inps.startinsarmaps)
 	logger.info("\t\t--testsheet	    : %s\n", inps.test_sheet)
-	
 
-	
+
 ###################### Auxiliary Functions #####################
 
-
-"""
-    Reads template file for the current dataset and parses out the 'ssaraopt' option before creating command options line options 
-    array for ssara_federated_query.py
-    Parameters: none
-    Returns:    ssara_options: [str], array of command line options to run ssara_federated_query with
-"""
 def create_ssara_options():
-	
-	with open('/nethome/'+user+'/insarlab/OPERATIONS/TEMPLATES/'+dataset+'.template', 'r') as template_file:
+	""" Reads template file for the current dataset and parses out the 'ssaraopt' option before creating command options
+		line options array for ssara_federated_query.py
+
+		Parameters: none
+		Returns:    ssara_options: [str], array of command line options to run ssara_federated_query with
+	"""
+
+	with open('/nethome/' + user + '/insarlab/OPERATIONS/TEMPLATES/' + dataset + '.template', 'r') as template_file:
 		options = ''
 		for line in template_file:
 			if 'ssaraopt' in line:
 				options = line.strip('\n').rstrip().split("= ")[1]
 				break;
-					
+
 	# Compute SSARA options to use
 	options = options.split(' ')
 
-	ssara_options = ['ssara_federated_query.py'] + options + ['--print']	
-		
+	ssara_options = ['ssara_federated_query.py'] + options + ['--print']
+
 	return ssara_options
-		
-"""
-    Reads the most recently stored date for the given dataset from the stored_date.date file, and parses the newest data date from ssara_federated_query.
-    Parameters: ssara_output: str, string output from ssara_federated_query.py ... --print
-    Returns:    none
-"""
+
+
 def set_dates(ssara_output):
+	""" Reads the most recently stored date for the given dataset from the stored_date.date file, and parses the newest
+		data date from ssara_federated_query.
+
+		Parameters: ssara_output: str, string output from ssara_federated_query.py ... --print
+		Returns:    none
+	"""
 	global stored_date, most_recent
-	
+
 	most_recent_data = ssara_output.split("\n")[-2]
 	most_recent = datetime.strptime(most_recent_data.split(",")[3], date_format)
 
 	# Write Most Recent Date to File
-	with open(os.getenv('OPERATIONS')+'/stored_date.date', 'rb') as stored_date_file:
-	
+	with open(os.getenv('OPERATIONS') + '/stored_date.date', 'rb') as stored_date_file:
+
 		try:
-			date_line = subprocess.check_output(['grep', dataset, os.getenv('OPERATIONS')+'/stored_date.date']).decode('utf-8')
+			date_line = subprocess.check_output(
+				['grep', dataset, os.getenv('OPERATIONS') + '/stored_date.date']).decode('utf-8')
 			stored_date = datetime.strptime(date_line.split(": ")[1].strip('\n'), date_format)
 		except subprocess.CalledProcessError as e:
-			
+
 			stored_date = datetime.strptime("1970-01-01T12:00:00.000000", date_format)
-			
-			with open(os.getenv('OPERATIONS')+'/stored_date.date', 'a+') as date_file:
-				data = str(dataset + ": "+str(datetime.strftime(most_recent, date_format))+"\n")
+
+			with open(os.getenv('OPERATIONS') + '/stored_date.date', 'a+') as date_file:
+				data = str(dataset + ": " + str(datetime.strftime(most_recent, date_format)) + "\n")
 				date_file.write(data)
 
-"""
-    Compares the most recent and stored dates 
-    Parameters: none
-    Returns:    boolean, whether the most recent data is more recent than the stored date
-"""
+
 def compare_dates():
+	""" Compares the most recent and stored dates
+
+		Parameters: none
+		Returns:    boolean, whether the most recent data is more recent than the stored date
+	"""
 	global stored_date, most_recent
-	
+
 	return most_recent > stored_date
-	
-"""
-    Overwrites the date stored in the stored_date.date file for the given dataset
-    Parameters: none
-    Returns:    none
-"""
+
+
 def overwrite_stored_date():
+	""" Overwrites the date stored in the stored_date.date file for the given dataset
+
+		Parameters: none
+		Returns:    none
+	"""
 	global user, most_recent
-	
+
 	data = []
-	with open(os.getenv('OPERATIONS')+'/stored_date.date', 'r') as date_file:
+	with open(os.getenv('OPERATIONS') + '/stored_date.date', 'r') as date_file:
 		data = date_file.readlines();
-	
+
 	for i, line in enumerate(data):
 		if dataset in line:
-			data[i] = str(dataset + ": "+str(datetime.strftime(most_recent, date_format))+"\n")
-	
-	with open(os.getenv('OPERATIONS')+'/stored_date.date', 'w') as date_file:
+			data[i] = str(dataset + ": " + str(datetime.strftime(most_recent, date_format)) + "\n")
+
+	with open(os.getenv('OPERATIONS') + '/stored_date.date', 'w') as date_file:
 		date_file.writelines(data)
 
-"""
-    Submits a  processSentinel.py job with the associated options as defined by the provided command line arguments
-    Parameters: none
-    Returns:    [files], [str] an array of file paths to the processSentinel output and error files
-"""
+
 def run_process_sentinel():
+	""" Submits a processSentinel.py job with the associated options as defined by the provided command line arguments
+
+		Parameters: none
+		Returns:    [files], [str] an array of file paths to the processSentinel output and error files
+	"""
 	global user, dataset
-	
+
 	psen_extra_options = []
-	
+
 	if inps.startssara:
 		psen_extra_options.append('--startssara')
 	if inps.startprocess:
-		psen_extra_options.append('--startprocess') 
+		psen_extra_options.append('--startprocess')
 	if inps.startpysar:
 		psen_extra_options.append('--startpysar')
 	if inps.startinsarmaps:
 		psen_extra_options.append('--startinsarmaps')
-		
+
 	if len(psen_extra_options) == 0:
 		psen_extra_options.append('--insarmaps')
-		
-	psen_options = ['process_sentinel.py', os.getenv('OPERATIONS')+'/TEMPLATES/'+dataset+'.template'] + psen_extra_options + ['--bsub']
-	
+
+	psen_options = ['process_sentinel.py',
+					os.getenv('OPERATIONS') + '/TEMPLATES/' + dataset + '.template'] + psen_extra_options + ['--bsub']
+
 	psen_output = subprocess.check_output(psen_options).decode('utf-8')
-	
+
 	job_number = psen_output.split('\n')[0].split("<")[1].split('>')[0]
 	logger.info("JOB NUMBER: %s", job_number)
-	
+
 	job_to_dset[job_number] = dataset
-	
-	stdout_file_path = os.getenv('SCRATCHDIR')+'/'+dataset+'/z_processSentinel_'+job_number+'.o'
-	stderr_file_path = os.getenv('SCRATCHDIR')+'/'+dataset+'/z_processSentinel_'+job_number+'.e'
-	
+
+	stdout_file_path = os.getenv('SCRATCHDIR') + '/' + dataset + '/z_processSentinel_' + job_number + '.o'
+	stderr_file_path = os.getenv('SCRATCHDIR') + '/' + dataset + '/z_processSentinel_' + job_number + '.e'
+
 	return [stdout_file_path, stderr_file_path]
 
-"""
-    Copies the output and error files from processSentinel to the $OPERATIONS/ERRORS directory
-    Parameters: files_to_move: [str], arrays of files to move to the ERRORS directory
-    Returns:    none
-"""
+
 def post_processing(files_to_move):
+	""" Copies the output and error files from processSentinel to the $OPERATIONS/ERRORS directory
+
+		Parameters: files_to_move: [str], arrays of files to move to the ERRORS directory
+		Returns:    none
+	"""
 	global output_file, most_recent
-	
+
 	job = files_to_move[0].split('/z_processSentinel_')[1].strip(".o")
-	
+
 	setup_logging_handlers(job_to_dset[job], "a+")
-	
+
 	for file in files_to_move:
 		if os.path.exists(file) and os.path.isfile(file):
 
-			base = os.getenv('OPERATIONS') + '/ERRORS/'+dataset+'/'
+			base = os.getenv('OPERATIONS') + '/ERRORS/' + dataset + '/'
 
 			if not os.path.exists(base):
 				os.makedirs(base)
@@ -264,10 +275,10 @@ def post_processing(files_to_move):
 				dest += '.e'
 
 			shutil.copy(file, dest)
-			
+
 		else:
 			raise IOError
-			
+
 	logger.removeHandler(info_handler)
 	logger.removeHandler(error_handler)
 
@@ -275,12 +286,12 @@ def post_processing(files_to_move):
 if __name__ == "__main__":
 
 	from datetime import datetime
-	
+
 	logger.info("RUN_OPERATIONS for %s:\n", datetime.fromtimestamp(time.time()).strftime(date_format))
-	
+
 	# Parse command line arguments
 	command_line_parse(sys.argv[1:])
-	
+
 	# Generate Template Files
 	template_options = []
 	if inps.template_csv:
@@ -291,38 +302,36 @@ if __name__ == "__main__":
 		template_options.append(inps.dataset)
 	if inps.test_sheet:
 		template_options.append('--testsheet')
-	
+
 	gt.main(template_options);
-	
+
 	datasets = []
-	
+
 	templates_directory = os.getenv('OPERATIONS') + "/TEMPLATES/"
-	
+
 	# Obtains list of datasets to run processSentinel on
-	datasets = glob.glob(templates_directory+"*.template")
-	datasets = [d.split('.', 1)[0].split('/')[-1] for d in datasets]	
+	datasets = glob.glob(templates_directory + "*.template")
+	datasets = [d.split('.', 1)[0].split('/')[-1] for d in datasets]
 	if inps.dataset:
 		datasets = [d for d in datasets if d == inps.dataset]
 
 	all_output_files = []
-	
-	
-	logger.info("\tDATASETS: \n "+str(datasets))
-	
+
+	logger.info("\tDATASETS: \n " + str(datasets))
 
 	# Perform the processing routine for each dataset
 	for dset in datasets:
-		
+
 		dataset = dset;
-		
+
 		setup_logging_handlers(dataset, "a")
-		
+
 		# Generate SSARA Options to Use
 		ssara_options = create_ssara_options()
-		
-		# Run SSARA and check output	
+
+		# Run SSARA and check output
 		ssara_output = subprocess.check_output(ssara_options).decode('utf-8');
-		
+
 		# Sets date variables for stored and most recent dates
 		set_dates(ssara_output)
 
@@ -332,31 +341,32 @@ if __name__ == "__main__":
 
 			# Write that stored date was overwritten
 			overwrite_stored_date()
-			
+
 			# Submit job via process_sentinel and store output
 			logger.info("%s: STARTING PROCESS SENTINEL JOB AT: %s (newest date: %s)\n", dataset, psen_time, most_recent)
 			files_to_move = run_process_sentinel()
-			
+
 			all_output_files += files_to_move;
-			
+
 		else:
 			logger.info("%s: NO NEW DATA on %s (most recent: %s)\n", dataset, psen_time, stored_date)
 
 		logger.removeHandler(info_handler)
 		logger.removeHandler(error_handler)
-		
+
 		# Perform post processing on all of the output and error files produced by processSentinel
 		while len(all_output_files) != 0:
 			for i, file in enumerate(all_output_files):
 				if os.path.exists(file) and os.path.isfile(file):
-					files_to_move = [all_output_files[i], all_output_files[i+1]]
+					files_to_move = [all_output_files[i], all_output_files[i + 1]]
 					post_processing(files_to_move)
-				
-					all_output_files[:] = [f for fi in files_to_move if fi not in file and fi not in all_output_files[i+1]]
-				
+
+					all_output_files[:] = [f for fi in files_to_move if
+										   fi not in file and fi not in all_output_files[i + 1]]
+
 			time.sleep(60)
-			
+
 		logger.info("\tCOMPLETED AT: %s", datetime.fromtimestamp(time.time()).strftime(date_format))
-		logger.info("----------------------------------\n")	
-	
+		logger.info("----------------------------------\n")
+
 	sys.exit()

--- a/run_operations.py
+++ b/run_operations.py
@@ -169,9 +169,10 @@ def set_dates(ssara_output):
 
 	# Checks if the stored_date.date file exists and created the file+directories if it doesn't
 	filename = os.getenv('OPERATIONS') + '/stored_date.date'
-	if not os.path.exists(os.path.dirname(filename)):
-		os.makedirs(os.path.dirname(filename))
-		open(filename, 'a').close()
+	if not os.path.exists(filename):
+		if not os.path.exists(os.path.dirname(filename)):
+			os.makedirs(os.path.dirname(filename))
+		subprocess.Popen("touch "+filename, shell=True).wait()
 
 	# Write Most Recent Date to File
 	with open(filename, 'rb') as stored_date_file:

--- a/run_operations.py
+++ b/run_operations.py
@@ -20,7 +20,9 @@ logger.setLevel(logging.DEBUG)
 
 std_formatter = logging.Formatter("%(message)s")
 
-general = logging.FileHandler(os.getenv('OPERATIONS') + '/LOGS/run_operations.log', 'a+', encoding=None)
+logfilename = os.getenv('OPERATIONS') + '/LOGS/run_operations.log'
+os.makedirs(os.path.dirname(logfilename), exist_ok=True)
+general = logging.FileHandler(logfilename, 'a+', encoding=None)
 general.setLevel(logging.INFO)
 general.setFormatter(std_formatter)
 logger.addHandler(general)
@@ -60,6 +62,7 @@ def setup_logging_handlers(dset, mode):
 
 	# create a file handler for INFO level logging
 	info_log_file = os.getenv('OPERATIONS') + '/LOGS/' + dset + '_info.log'
+	os.makedirs(os.path.dirname(info_log_file), exist_ok=True)
 	info_handler = logging.FileHandler(info_log_file, mode, encoding=None)
 	info_formatter = logging.Formatter("%(levelname)s - %(message)s")
 	info_handler.setLevel(logging.INFO)
@@ -68,6 +71,7 @@ def setup_logging_handlers(dset, mode):
 
 	# create a file handler for ERROR level logging
 	error_log_file = os.getenv('OPERATIONS') + '/LOGS/' + dset + '_error.log'
+	os.makedirs(os.path.dirname(error_log_file), exist_ok=True)
 	error_handler = logging.FileHandler(error_log_file, mode, encoding=None)
 	err_formatter = logging.Formatter("%(levelname)s - %(message)s")
 	error_handler.setLevel(logging.ERROR)
@@ -163,8 +167,14 @@ def set_dates(ssara_output):
 	most_recent_data = ssara_output.split("\n")[-2]
 	most_recent = datetime.strptime(most_recent_data.split(",")[3], date_format)
 
+	# Checks if the stored_date.date file exists and created the file+directories if it doesn't
+	filename = os.getenv('OPERATIONS') + '/stored_date.date'
+	if not os.path.exists(os.path.dirname(filename)):
+		os.makedirs(os.path.dirname(filename))
+		open(filename, 'a').close()
+
 	# Write Most Recent Date to File
-	with open(os.getenv('OPERATIONS') + '/stored_date.date', 'rb') as stored_date_file:
+	with open(filename, 'rb') as stored_date_file:
 
 		try:
 			date_line = subprocess.check_output(

--- a/run_operations.py
+++ b/run_operations.py
@@ -271,8 +271,8 @@ def post_processing(files_to_move):
 
 	setup_logging_handlers(job_to_dset[job], "a+")
 
-	for file in files_to_move:
-		if os.path.exists(file) and os.path.isfile(file):
+	for filename in files_to_move:
+		if os.path.exists(filename) and os.path.isfile(filename):
 
 			base = os.getenv('OPERATIONS') + '/ERRORS/' + dataset + '/'
 
@@ -280,12 +280,12 @@ def post_processing(files_to_move):
 				os.makedirs(base)
 
 			dest = base + str(most_recent)[0:10]
-			if file[-1] is 'o':
+			if filename[-1] is 'o':
 				dest += '.o'
-			elif file[-1] is 'e':
+			elif filename[-1] is 'e':
 				dest += '.e'
 
-			shutil.copy(file, dest)
+			shutil.copy(filename, dest)
 
 		else:
 			raise IOError


### PR DESCRIPTION
`run_operations` relies on a multitude of files and directories existing for the proper organization of log, error, and template files. Perviously if any of those directories or files didn't exist when accessed, run_operations would simply throw and error and exit. 

This Pull Request implements proper handling of file and directory creation so that, should those directories or files not exist, they are created, ensuring that manual creation of those files and folders doesn't need to be done before running `run_operations` on a new system.

Closes #20 