### PR TITLE
Moved `ssh_with_commands` and refactored `subprocess` email patterns

### DIFF
--- a/download_rsmas.py
+++ b/download_rsmas.py
@@ -38,19 +38,6 @@ def create_parser():
     # parser.add_argument('template_file', help='template file containing ssaraopt field', nargs='?')
     return parser
 
-def ssh_with_commands(hostname, command_list):
-    """
-    Uses subprocess to ssh into a specified host and run the given commands.
-    :param hostname: Name of host to ssh to.
-    :param command_list: List of commands to run after connecting via ssh.
-    :return: Exit status from subprocess.
-    """
-    ssh_proc = subprocess.Popen(['ssh', hostname, 'bash -s -l'], stdin=subprocess.PIPE)
-    for cmd in command_list:
-        ssh_proc.stdin.write(cmd.encode('utf8'))
-        ssh_proc.stdin.write('\n'.encode('utf8'))
-    ssh_proc.communicate()
-    return ssh_proc.returncode
 
 def download(script_name, template_file, slc_dir, outnum):
     """
@@ -75,9 +62,9 @@ def download(script_name, template_file, slc_dir, outnum):
     else:
         ssh_command_list = ['s.bgood', 'cd {0}'.format(slc_dir), command]
         host = os.getenv('DOWNLOADHOST')
-        status = ssh_with_commands(host, ssh_command_list)
+        status = putils.ssh_with_commands(host, ssh_command_list)
 
-    print('Exit status from download_{0}_rsmas.py: {1}'.format(script_name, status))
+        print('Exit status from download_{0}_rsmas.py: {1}'.format(script_name, status))
 
 ###############################################################################
 

--- a/email_pysar_results.py
+++ b/email_pysar_results.py
@@ -9,9 +9,7 @@ import os
 import sys
 import glob
 import argparse
-import subprocess
 
-import messageRsmas
 import _process_utilities as putils
 
 from dataset_template import Template
@@ -106,23 +104,25 @@ def main(iargs=None, text_string='email pysar results'):
     cwd = os.getcwd()
     #import pdb; pdb.set_trace()
     for file_list in file_lists:
-       print ('###')
-       attachment_string = ''
-       i = i + 1
-       for fname in file_list:
+        print ('###')
+        attachment_string = ''
+        i = i + 1
+        for fname in file_list:
            files = glob.glob(prefix+'/'+fname)
            for file in files:
                attachment_string = attachment_string+' -a '+file
 
-       if i==1 and len(template_file)>0:
-          attachment_string = attachment_string+' -a '+template_file
+        if i==1 and len(template_file)>0:
+            attachment_string = attachment_string+' -a '+template_file
 
-       mail_command = 'echo \"'+text_string+'\" | mail -s '+cwd+' '+attachment_string+' '+ email_list
-       command = 'ssh pegasus.ccs.miami.edu \"cd '+cwd+'; '+mail_command+'\"'
-       print(command)
-       status = subprocess.Popen(command, shell=True).wait()
-       if status is not 0:
-          sys.exit('Error in email_pysar_results')
+        mail_command = 'echo \"'+text_string+'\" | mail -s '+cwd+' '+attachment_string+' '+ email_list
+
+        status = putils.ssh_with_commands(hostname="pegasus.ccs.miami.edu", command_list=['cd ' + cwd, mail_command])
+
+        print('ssh pegasus.ccs.miami.edu cd ' + cwd + "; " + mail_command)
+
+        if status is not 0:
+            raise Exception('Error in email_pysar_results')
 
 
 ###########################################################################################

--- a/rerun_job_if_FileExistsError.py
+++ b/rerun_job_if_FileExistsError.py
@@ -10,14 +10,17 @@ create them as needed
 import os
 import glob
 import subprocess
+import _process_utilities as putils
 
 def email_rerun_message(file_name):
-    long_name = os.getcwd().split('/')[-2] + '/' + os.getcwd().split('/')[-1] + '/' + file_name
+    cwd = os.getcwd()
+    long_name = "/".join(cwd.split('/')[-2:]) + '/' + file_name
     text_str = 'Now rerunning because of FileExists error:' + file_name
-    mail_cmd = 'echo \"'+text_str+'\" | mail -s RERUNNING:_' + long_name + ' ' +  os.getenv('NOTIFICATIONEMAIL')  
-    command = 'ssh pegasus.ccs.miami.edu \"cd '+os.getcwd()+'; '+mail_cmd+'\"'
-    print(command)
-    status = subprocess.Popen(command, shell=True).wait()
+
+    mail_command = 'echo \"'+text_str+'\" | mail -s RERUNNING:_' + long_name + ' ' +  os.getenv('NOTIFICATIONEMAIL')
+    status = putils.ssh_with_commands(hostname='pegasus.ccs.miami.edu', command_list=['cd ' + os.getcwd(), mail_command])
+    print('ssh pegasus.ccs.miami.edu cd ' + os.getcwd() + "; " + mail_command)
+
     if status is not 0:
        raise Exception('ERROR in email_rerun_message')
 


### PR DESCRIPTION
`ssh_with_commands` was written for `download_rsmas.py` but the pattern is used by multiple scripts for data download and sending emails. This function is now used instead of `ssh`ing via a subprocess call inline. Note that `ssh_with_commands` does make a subprocess call, but now we have isolated it to a single function.

Future work: Return Exceptions along with the process error code from `ssh_with_commands`. 

@lily-wittle