### PR TITLE
Changed process_rsmas logic flow

### DIFF
--- a/create_batch.py
+++ b/create_batch.py
@@ -152,9 +152,8 @@ def write_single_job_file(job_name, job_file_name, command_line, work_dir, email
     job_file_lines.append("\n" + command_line + "\n")
 
     # write lines to .job file
-    os.chdir(work_dir)
     job_file_name = "{0}.job".format(job_file_name)
-    with open(job_file_name, "w+") as job_file:
+    with open(os.path.join(work_dir, job_file_name), "w+") as job_file:
         job_file.writelines(job_file_lines)
 
 
@@ -274,7 +273,6 @@ def submit_script(job_name, job_file_name, argv, work_dir, walltime, email_notif
     write_single_job_file(job_name, job_file_name, command_line, work_dir, email_notif,
                           walltime=walltime, queue=os.getenv("QUEUENAME"))
     submit_single_job("{0}.job".format(job_file_name))
-    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/process_rsmas.py
+++ b/process_rsmas.py
@@ -23,7 +23,7 @@ logger_process_rsmas  = send_logger()
 ###############################################################################
 
 
-def main(inps):
+def process(inps):
 
     #########################################
     # Initiation
@@ -130,4 +130,4 @@ if __name__ == "__main__":
 
         cb.submit_script(project_name, job_file_name, sys.argv[:], work_dir, wall_time)
     else:
-        main(inps)
+        process(inps)

--- a/process_rsmas.py
+++ b/process_rsmas.py
@@ -13,7 +13,7 @@ import os
 import sys
 import time
 import messageRsmas
-from _process_utilities  import get_work_directory, get_project_name, send_logger, _remove_directories
+from _process_utilities import get_work_directory, get_project_name, send_logger, _remove_directories
 import _processSteps as prs
 import create_batch as cb
 from rsmas_logging import loglevel
@@ -23,7 +23,39 @@ logger_process_rsmas  = send_logger()
 ###############################################################################
 
 
-def main(start_time):
+def main(inps):
+
+    #########################################
+    # Initiation
+    #########################################
+    start_time = time.time()
+
+    inps.project_name = get_project_name(inps.custom_template_file)
+    inps.work_dir = get_work_directory(None, inps.project_name)
+    inps.slc_dir = os.path.join(inps.work_dir, 'SLC')
+
+    if inps.remove_project_dir:
+        _remove_directories(directories_to_delete=[inps.work_dir])
+
+    if not os.path.isdir(inps.work_dir):
+        os.makedirs(inps.work_dir)
+    os.chdir(inps.work_dir)
+
+    #  Read and update template file:
+    inps = prs.create_or_update_template(inps)
+    print(inps)
+    if not inps.processingMethod or inps.workflow == 'interferogram':
+        inps.processingMethod = 'sbas'
+
+    if not os.path.isdir(inps.slc_dir):
+        os.makedirs(inps.slc_dir)
+
+    command_line = os.path.basename(sys.argv[0]) + ' ' + ' '.join(sys.argv[1:])
+    logger_process_rsmas.log(loglevel.INFO, '##### NEW RUN #####')
+    logger_process_rsmas.log(loglevel.INFO, 'process_rsmas.py ' + command_line)
+    messageRsmas.log('##### NEW RUN #####')
+    messageRsmas.log(command_line)
+
     #########################################
     # startssara: Getting Data
     #########################################
@@ -84,38 +116,7 @@ def main(start_time):
 
 if __name__ == "__main__":
 
-    #########################################
-    # Initiation
-    #########################################
-
-    start_time = time.time()
     inps = prs.command_line_parse()
-
-    inps.project_name = get_project_name(inps.custom_template_file)
-    inps.work_dir = get_work_directory(None, inps.project_name)
-    inps.slc_dir = os.path.join(inps.work_dir,'SLC')
-
-    if inps.remove_project_dir:
-        _remove_directories(directories_to_delete=[inps.work_dir])
-
-    if not os.path.isdir(inps.work_dir):
-        os.makedirs(inps.work_dir)
-    os.chdir(inps.work_dir)
-
-    #  Read and update template file:
-    inps = prs.create_or_update_template(inps)
-    print(inps)
-    if not inps.processingMethod or inps.workflow=='interferogram':
-        inps.processingMethod='sbas'
-
-    if not os.path.isdir(inps.slc_dir):
-        os.makedirs(inps.slc_dir)
-
-    command_line = os.path.basename(sys.argv[0]) + ' ' + ' '.join(sys.argv[1:])
-    logger_process_rsmas.log(loglevel.INFO, '##### NEW RUN #####')
-    logger_process_rsmas.log(loglevel.INFO, 'process_rsmas.py ' + command_line)
-    messageRsmas.log('##### NEW RUN #####')
-    messageRsmas.log(command_line)
     
     #########################################
     # Submit job
@@ -123,6 +124,10 @@ if __name__ == "__main__":
     if inps.submit_flag:
         job_file_name = 'process_rsmas'
         wall_time = '48:00'
-        cb.submit_script(inps.project_name, job_file_name, sys.argv[:], inps.work_dir, wall_time)
+
+        project_name = get_project_name(inps.custom_template_file)
+        work_dir = get_work_directory(None, inps.project_name)
+
+        cb.submit_script(project_name, job_file_name, sys.argv[:], work_dir, wall_time)
     else:
-        main(start_time)
+        main(inps)

--- a/process_rsmas.py
+++ b/process_rsmas.py
@@ -23,6 +23,65 @@ logger_process_rsmas  = send_logger()
 ###############################################################################
 
 
+def main(start_time):
+    #########################################
+    # startssara: Getting Data
+    #########################################
+
+    # running download scripts:
+    #     download_ssara_rsmas.py $TE/template
+    #     downlaod_asfserial_rsmas.py $TE/template
+    prs.call_ssara(inps.flag_ssara, inps.custom_template_file, inps.slc_dir)
+
+    #########################################
+    # startmakerun: create run files
+    #########################################
+
+    # create or copy DEM
+    # running the script:
+    #     dem_rsmas.py $TE/template
+
+    prs.create_or_copy_dem(inps, inps.work_dir, inps.template, inps.custom_template_file)
+
+    # Check for DEM and create sentinel run files
+    # running the script:
+    #     create_stacksentinel_run_files.py $TE/template
+
+    prs.create_runfiles(inps)
+
+    #########################################
+    # startprocess: Execute run files
+    #########################################
+
+    # Running the script:
+    #    execute_stacksentinel_run_files.py $TE/template starting_run stopping_run
+    #    Example for running run 1 to 4:
+    #    execute_stacksentinel_run_files.py $TE/template 1 4
+
+    prs.process_runfiles(inps)
+
+    #########################################
+    # startpysar: running PySAR and email results
+    #########################################
+
+    if inps.processingMethod == 'squeesar':
+        # Run squeesar script:
+        #    create_squeesar_run_files.py $TE/template
+        #    execute_squeesar_run_files.py $TE/template
+        prs.process_time_series(inps)
+    else:
+        # Run PySAR script:
+        #    pysarApp.py $TE/template
+        prs.run_pysar(inps, start_time)
+
+    # Run ingest insarmaps script and email results
+    #    ingest_insarmaps.py $TE/template
+
+    prs.run_ingest_insarmaps(inps)
+
+    logger_process_rsmas.log(loglevel.INFO, 'End of process_rsmas')
+
+
 if __name__ == "__main__":
 
     #########################################
@@ -65,61 +124,5 @@ if __name__ == "__main__":
         job_file_name = 'process_rsmas'
         wall_time = '48:00'
         cb.submit_script(inps.project_name, job_file_name, sys.argv[:], inps.work_dir, wall_time)
-
-    #########################################
-    # startssara: Getting Data
-    #########################################
-
-    # running download scripts:
-    #     download_ssara_rsmas.py $TE/template
-    #     downlaod_asfserial_rsmas.py $TE/template
-    prs.call_ssara(inps.flag_ssara, inps.custom_template_file, inps.slc_dir)
-
-    #########################################
-    # startmakerun: create run files
-    #########################################
-
-    # create or copy DEM
-    # running the script:
-    #     dem_rsmas.py $TE/template
-
-    prs.create_or_copy_dem(inps, inps.work_dir, inps.template, inps.custom_template_file)
-
-    # Check for DEM and create sentinel run files
-    # running the script:
-    #     create_stacksentinel_run_files.py $TE/template
-
-    prs.create_runfiles(inps)
-
-    #########################################
-    # startprocess: Execute run files
-    #########################################
-
-    # Running the script:
-    #    execute_stacksentinel_run_files.py $TE/template starting_run stopping_run
-    #    Example for running run 1 to 4:
-    #    execute_stacksentinel_run_files.py $TE/template 1 4
-
-    prs.process_runfiles(inps)
-
-    #########################################
-    # startpysar: running PySAR and email results
-    #########################################
-
-
-    if inps.processingMethod == 'squeesar' :
-        # Run squeesar script:
-        #    create_squeesar_run_files.py $TE/template
-        #    execute_squeesar_run_files.py $TE/template
-        prs.process_time_series(inps)
     else:
-        # Run PySAR script:
-        #    pysarApp.py $TE/template
-        prs.run_pysar(inps, start_time)
-
-    # Run ingest insarmaps script and email results
-    #    ingest_insarmaps.py $TE/template
-
-    prs.run_ingest_insarmaps(inps)
-
-    logger_process_rsmas.log(loglevel.INFO, 'End of process_rsmas')
+        main(start_time)


### PR DESCRIPTION
`process_rsmas` now either submits `process_rsmas` as a job file via
`create_batch.submit_script()` or runs the remainder of the routine in
a serial fashion, but not both. This should guarantee that, with the
removal of the `sys.exit()` call from `create_batch`, the main body of
`process_rsmas` is not run twice.

Solves #103 

@2gotgrossman 