### PR TITLE
Added detailed message for job submission

### DIFF
--- a/rinsar/create_batch.py
+++ b/rinsar/create_batch.py
@@ -218,6 +218,8 @@ def submit_single_job(job_file_name, work_dir, scheduler=None):
     else:
         raise Exception("ERROR: scheduler {0} not supported".format(scheduler))
 
+    print("{0} submitted as {1} job #{2}".format(job_file_name, scheduler, job_number))
+
     return job_number
 
 
@@ -237,11 +239,13 @@ def submit_batch_jobs(job_files, batch_file, out_dir, scheduler=None):
 
     files = []
 
-    for job in job_files:
+    for i, job in enumerate(job_files):
         job_number = submit_single_job(job, work_dir, scheduler)
         job_file_name = job.split(".")[0]
         files.append("{}_{}.o".format(job_file_name, job_number))
         # files.append("{}_{}.e".format(job_file_name, job_number))
+        if len(job_files) < 100 or i == 0 or i % 50 == 49:
+            print("Submitting from {0}: job #{1} of {2} jobs".format(batch_file.split(os.sep)[-1], i+1, len(job_files)))
 
     # check if output files exist
     i = 0


### PR DESCRIPTION
After each job submission, prints detailed message with scheduler and job number. Ex) `process_rsmas.job submitted as LSF job #20317933`

For batch job submission, prints message with the progress of the batch submission. For run files with 100+ jobs, only prints every 50 jobs after the first. Ex) `Submitting from run_1_unpack_topo: job #1 from 1256 jobs`