### PR TITLE
job_submisson.py: uses MAX_JOBS_PER_WORKFLOW instead of MAX_JOBS_PER_…

### DIFF
--- a/minsar/defaults/minsar_template.cfg
+++ b/minsar/defaults/minsar_template.cfg
@@ -101,6 +101,7 @@ WALLTIME_FACTOR               = auto       # default = 1  this factor multiplies
 CPUS_PER_NODE                 = auto       # defaults based on the above systems
 THREADS_PER_CORE              = auto       # defaults based on the above systems
 MEM_PER_NODE                  = auto       # defaults based on the above systems
+MAX_JOBS_PER_WORKFLOW         = auto       # defaults based on the above systems
 MAX_JOBS_PER_QUEUE            = auto       # defaults based on the above systems
 
 # Following are the job submission schemes supported by minsar:

--- a/minsar/defaults/queues.cfg
+++ b/minsar/defaults/queues.cfg
@@ -1,25 +1,25 @@
-PLATFORM_NAME  QUEUENAME     CPUS_PER_NODE  THREADS_PER_CORE  MEM_PER_NODE  MAX_JOBS_PER_QUEUE  WALLTIME_FACTOR
-stampede2      skx-normal         48                 2             192000            12                 1
-stampede2      skx-dev            48                 2             192000            1                  1
-stampede2      normal             48                 4             96000             50                 1
-stampede2      development        48                 4             96000             1                  1
-frontera       normal             48                 1             192000            200                2.5
-frontera       nvdimm             48                 1             2100000           8                  2.5
-frontera       development        48                 1             192000            1                  2.5
-frontera       rtx                15                 1             128000            45                 2.5
-frontera       rtx-dev            15                 1             128000            3                  2.5
-frontera       flex               48                 1             192000            200                2.5
-eos_sanghoon   batch              32                 2             192000            999                1
-eos            batch              32                 2             192000            999                1
-comet          gpu                24                 1             20000             25                 1
-comet          shared             24                 1             20000             25                 1
-comet          compute            24                 1             20000             25                 1
-pegasus        general            16                 2             25000             999                1
-pegasus        parallel           16                 2             25000             999                1
-pegasus        bigmem             64                 2             25000             999                1
-beijing_server batch              16                 2             192000            999                1
-deqing_server  batch              32                 2             192000            999                1
-dqcentos7insar batch              32                 2             192000            999                1
+PLATFORM_NAME  QUEUENAME     CPUS_PER_NODE  THREADS_PER_CORE  MEM_PER_NODE  MAX_JOBS_PER_WORKFLOW  MAX_JOBS_PER_QUEUE  WALLTIME_FACTOR
+stampede2      skx-normal         48                 2             192000            12                    25                  1
+stampede2      skx-dev            48                 2             192000            1                     25                  1
+stampede2      normal             48                 4             96000             50                    25                  1
+stampede2      development        48                 4             96000             1                     25                  1
+frontera       normal             48                 1             192000            12                   100                  2.5
+frontera       nvdimm             48                 1             2100000           8                    100                  2.5
+frontera       development        48                 1             192000            1                    100                  2.5
+frontera       rtx                15                 1             128000            45                   100                  2.5
+frontera       rtx-dev            15                 1             128000            3                    100                  2.5
+frontera       flex               48                 1             192000            200                  100                  2.5
+eos_sanghoon   batch              32                 2             192000            999                  100                  1
+eos            batch              32                 2             192000            999                   25                  1
+comet          gpu                24                 1             20000             25                    25                  1
+comet          shared             24                 1             20000             25                    25                  1
+comet          compute            24                 1             20000             25                    25                  1
+pegasus        general            16                 2             25000             999                   25                  1
+pegasus        parallel           16                 2             25000             999                   25                  1
+pegasus        bigmem             64                 2             25000             999                   25                  1
+beijing_server batch              16                 2             192000            999                   25                  1
+deqing_server  batch              32                 2             192000            999                   25                  1
+dqcentos7insar batch              32                 2             192000            999                   25                  1
 
 
 #nvidimm     # features 16 large-memory (2.1TB) nodes and jobs in this queue are charged at twice the normal

--- a/minsar/job_submission.py
+++ b/minsar/job_submission.py
@@ -111,7 +111,7 @@ class JOB_SUBMIT:
             self.prefix = 'tops'
 
         self.submission_scheme, self.platform_name, self.scheduler, self.queue_name, \
-        self.number_of_cores_per_node, self.number_of_threads_per_core, self.max_jobs_per_queue, \
+        self.number_of_cores_per_node, self.number_of_threads_per_core, self.max_jobs_per_workflow, \
         self.max_memory_per_node, self.wall_time_factor = set_job_queue_values(inps)
 
         if not 'num_bursts' in inps or not inps.num_bursts:
@@ -431,7 +431,7 @@ class JOB_SUBMIT:
         number_of_jobs = number_of_nodes
         number_of_nodes_per_job = 1
 
-        while number_of_jobs > int(self.max_jobs_per_queue):
+        while number_of_jobs > int(self.max_jobs_per_workflow):
             number_of_nodes_per_job = number_of_nodes_per_job + 1
             number_of_jobs = np.ceil(number_of_nodes/number_of_nodes_per_job)
 
@@ -441,7 +441,7 @@ class JOB_SUBMIT:
         #    import pdb; pdb.set_trace()
 
         while number_of_limited_memory_tasks < number_of_parallel_tasks:
-            if number_of_jobs < int(self.max_jobs_per_queue):
+            if number_of_jobs < int(self.max_jobs_per_workflow):
                 number_of_jobs += 1
                 number_of_parallel_tasks = int(np.ceil(len(tasks) / number_of_jobs))
             else:
@@ -764,6 +764,7 @@ def set_job_queue_values(args):
     check_auto = {'queue_name': template['QUEUENAME'],
                   'number_of_cores_per_node': template['CPUS_PER_NODE'],
                   'number_of_threads_per_core': template['THREADS_PER_CORE'],
+                  'max_jobs_per_workflow': template['MAX_JOBS_PER_WORKFLOW'],
                   'max_jobs_per_queue': template['MAX_JOBS_PER_QUEUE'],
                   'wall_time_factor': template['WALLTIME_FACTOR'],
                   'max_memory_per_node': template['MEM_PER_NODE']}
@@ -795,6 +796,8 @@ def set_job_queue_values(args):
                         check_auto['number_of_threads_per_core'] = int(split_values[queue_header.index('THREADS_PER_CORE')])
                     if check_auto['max_jobs_per_queue'] == 'auto':
                         check_auto['max_jobs_per_queue'] = int(split_values[queue_header.index('MAX_JOBS_PER_QUEUE')])
+                    if check_auto['max_jobs_per_workflow'] == 'auto':
+                        check_auto['max_jobs_per_workflow'] = int(split_values[queue_header.index('MAX_JOBS_PER_WORKFLOW')])
                     if check_auto['max_memory_per_node'] == 'auto':
                         check_auto['max_memory_per_node'] = int(split_values[queue_header.index('MEM_PER_NODE')])
                     if check_auto['wall_time_factor'] == 'auto':
@@ -824,7 +827,7 @@ def set_job_queue_values(args):
             i += 1
 
     out_puts = (submission_scheme, platform_name, scheduler, check_auto['queue_name'], check_auto['number_of_cores_per_node'],
-                check_auto['number_of_threads_per_core'], check_auto['max_jobs_per_queue'],
+                check_auto['number_of_threads_per_core'], check_auto['max_jobs_per_workflow'],
                 check_auto['max_memory_per_node'], check_auto['wall_time_factor'])
 
     return out_puts
@@ -832,7 +835,7 @@ def set_job_queue_values(args):
 
 def auto_template_not_existing_options(args):
 
-    job_options = ['QUEUENAME', 'CPUS_PER_NODE', 'THREADS_PER_CORE', 'MAX_JOBS_PER_QUEUE',
+    job_options = ['QUEUENAME', 'CPUS_PER_NODE', 'THREADS_PER_CORE', 'MAX_JOBS_PER_WORKFLOW', 'MAX_JOBS_PER_QUEUE',
                    'WALLTIME_FACTOR', 'MEM_PER_NODE', 'job_submission_scheme']
 
     if args.custom_template_file:


### PR DESCRIPTION
This PR allows to specify both MAX_JOBS_PER_WORKFLOW and MAX_JOBS_PER_QUEUE. This allows for example to run on Frontera 10 workkflows each using MAX_JOBS_PER_WORKFLOW=12 simultaneously.

- job_submission.py: replaced MAX_JOBS_PER_QUEUE by MAX_JOBS_PER_WORKFLOW
- queues.cfg: added MAX_JOBS_PER_WORKFLOW column (containing entries of previous MAX_JOBS_PER_QUEUE)